### PR TITLE
Always create a new ProjectComponent to remove data of old cities

### DIFF
--- a/Assets/Scripts/DataModel/Model.cs
+++ b/Assets/Scripts/DataModel/Model.cs
@@ -76,8 +76,7 @@ namespace DataModel
             if (baseComponent == null || components == null)
                 return null;
 
-            if (project == null)
-                project = new ProjectComponent(baseComponent);
+            project = new ProjectComponent(baseComponent);
 
             lock (project)
             {


### PR DESCRIPTION
Fixes a problem which occures when the user opens different projects without restarting the whole app. Due to the static Model, data from the new project was added to the old data which leads to an ever growing data set and huge cities.